### PR TITLE
fix(chat): resolve provider when using proxy endpoint in production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,11 +7,12 @@ VITE_AI_PROVIDER=
 
 # OpenRouter — https://openrouter.ai/settings/keys
 # Accesses Claude, Gemini, and 300+ models via one key.
+# Dev mode: used directly with auth header. Prod mode: ignored (proxy handles auth).
 VITE_OPENROUTER_API_KEY=
 # Model to use (default: anthropic/claude-haiku-4-5)
 VITE_OPENROUTER_MODEL=anthropic/claude-haiku-4-5
-# Proxy endpoint — set to your Cloudflare Worker URL to keep the key server-side.
-# If unset, calls OpenRouter directly (key exposed in bundle).
+# Proxy endpoint — Cloudflare Worker URL. Required in production to keep the key server-side.
+# Dev mode skips this and calls OpenRouter directly using VITE_OPENROUTER_API_KEY.
 VITE_AI_ENDPOINT=
 
 # Gemini 2.0 Flash (direct) — https://aistudio.google.com/app/apikey

--- a/src/components/ChatBot.tsx
+++ b/src/components/ChatBot.tsx
@@ -87,7 +87,7 @@ const ChatBot = () => {
                 role="dialog"
                 aria-label="Chat with Karl's AI assistant"
                 aria-modal="true"
-                className="fixed bottom-34 right-6 z-40 w-[380px] h-[560px] rounded-lg flex flex-col"
+                className="fixed bottom-15 right-23 z-40 w-[380px] h-[560px] rounded-lg flex flex-col"
                 style={{
                     background: 'var(--color-bg)',
                     border: '1px solid var(--color-hairline)',

--- a/src/lib/ai-chat.ts
+++ b/src/lib/ai-chat.ts
@@ -8,15 +8,16 @@ const PROVIDER_ENV = import.meta.env.VITE_AI_PROVIDER as string | undefined;
 const GEMINI_KEY = import.meta.env.VITE_GEMINI_API_KEY as string | undefined;
 const OPENROUTER_KEY = import.meta.env.VITE_OPENROUTER_API_KEY as string | undefined;
 const OPENROUTER_MODEL = (import.meta.env.VITE_OPENROUTER_MODEL as string | undefined) ?? 'anthropic/claude-haiku-4-5';
-// Set VITE_AI_ENDPOINT to your Cloudflare Worker URL to keep the key server-side
-const OPENROUTER_ENDPOINT =
-    (import.meta.env.VITE_AI_ENDPOINT as string | undefined) ?? 'https://openrouter.ai/api/v1/chat/completions';
+const OPENROUTER_ENDPOINT = import.meta.env.DEV
+    ? 'https://openrouter.ai/api/v1/chat/completions'
+    : ((import.meta.env.VITE_AI_ENDPOINT as string | undefined) ?? 'https://openrouter.ai/api/v1/chat/completions');
 
 function resolveProvider(): Provider | null {
-    if (PROVIDER_ENV === 'openrouter') return OPENROUTER_KEY ? 'openrouter' : null;
+    const hasProxy = !import.meta.env.DEV && !!import.meta.env.VITE_AI_ENDPOINT;
+    if (PROVIDER_ENV === 'openrouter') return OPENROUTER_KEY || hasProxy ? 'openrouter' : null;
     if (PROVIDER_ENV === 'gemini') return GEMINI_KEY ? 'gemini' : null;
     // auto-detect: OpenRouter first, then Gemini
-    if (OPENROUTER_KEY) return 'openrouter';
+    if (OPENROUTER_KEY || hasProxy) return 'openrouter';
     if (GEMINI_KEY) return 'gemini';
     return null;
 }
@@ -39,7 +40,7 @@ async function sendOpenRouter(history: Message[], userText: string): Promise<str
     ];
 
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-    if (OPENROUTER_KEY) headers['Authorization'] = `Bearer ${OPENROUTER_KEY}`;
+    if (import.meta.env.DEV && OPENROUTER_KEY) headers['Authorization'] = `Bearer ${OPENROUTER_KEY}`;
 
     const response = await fetch(OPENROUTER_ENDPOINT, {
         method: 'POST',


### PR DESCRIPTION
Chips and messages were unclickable on GitHub Pages because resolveProvider() returned null without an API key, even when VITE_AI_ENDPOINT (Cloudflare Worker proxy) was configured. Proxy handles auth server-side so no key needed in bundle.

Also restrict Authorization header to dev mode only and update .env.example docs.